### PR TITLE
 fix: improve error handling 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - 'Type: Meta'
+      - 'Type: Question'
+      - 'Type: Release'
+
+  categories:
+    - title: Security Fixes
+      labels: ['Type: Security']
+    - title: Breaking Changes
+      labels: ['Type: Breaking Change']
+    - title: Features
+      labels: ['Type: Feature']
+    - title: Bug Fixes
+      labels: ['Type: Bug']
+    - title: Documentation
+      labels: ['Type: Documentation']
+    - title: Refactoring
+      labels: ['Type: Refactoring']
+    - title: Testing
+      labels: ['Type: Testing']
+    - title: Maintenance
+      labels: ['Type: Maintenance']
+    - title: CI
+      labels: ['Type: CI']
+    - title: Dependency Updates
+      labels: ['Type: Dependencies', "dependencies"]
+    - title: Other Changes
+      labels: ['*']

--- a/src/express-lazy-router.ts
+++ b/src/express-lazy-router.ts
@@ -33,7 +33,7 @@ export function createLazyRouter(options: createLazyLoaderOptions = {}) {
         const resolveResolver = () => {
             return resolver().then((router) => {
                 if (!router) {
-                    throw new Error(`lazyLoad(resolve) the resolver function should return a promise object, but it returns falsy value: ${router}
+                    throw new Error(`lazyLoad(resolver) the resolver function should return a promise object, but it returns falsy value: ${router}
 
 You need to return a promise object from the callback function.
 

--- a/src/express-lazy-router.ts
+++ b/src/express-lazy-router.ts
@@ -33,7 +33,7 @@ export function createLazyRouter(options: createLazyLoaderOptions = {}) {
         const resolveResolver = () => {
             return resolver().then((router) => {
                 if (!router) {
-                    throw new Error(`lazyLoad(callback) the callback function should return a promise object, but got falsy value: ${router}
+                    throw new Error(`lazyLoad(resolve) the resolver function should return a promise object, but it returns falsy value: ${router}
 
 You need to return a promise object from the callback function.
 

--- a/src/express-lazy-router.ts
+++ b/src/express-lazy-router.ts
@@ -32,6 +32,14 @@ export function createLazyRouter(options: createLazyLoaderOptions = {}) {
         let loadedRouter: express.Router;
         const resolveResolver = () => {
             return resolver().then((router) => {
+                if (!router) {
+                    throw new Error(`lazyLoad(callback) the callback function should return a promise object, but got falsy value: ${router}
+
+You need to return a promise object from the callback function.
+
+    lazyLoad(() => import('./path_to_router')),                
+`);
+                }
                 if ("default" in router) {
                     loadedRouter = router.default;
                 } else {


### PR DESCRIPTION
lazyLoad just throw an error on following case:

```js
lazyLoad(() => undefined)
```

