### PR TITLE
Added name to middleware function

### DIFF
--- a/src/express-lazy-router.ts
+++ b/src/express-lazy-router.ts
@@ -47,7 +47,7 @@ You need to return a promise object from the callback function.
                 }
             });
         };
-        lazyRouter.use((req, res, next) => {
+        lazyRouter.use(function lazyRouterHandler(req, res, next) {
             if (loadedRouter) {
                 return loadedRouter(req, res, next);
             } else {


### PR DESCRIPTION
fixes https://github.com/azu/express-lazy-router/issues/7

- this allows code instrumentation tools (such as New Relic) to detect the function name instead of labelling it as `<anonymous>`